### PR TITLE
Bump POI to 4.1.1 and fix errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
   	<dependency>
   		<groupId>org.bbreak.excella</groupId>
   		<artifactId>excella-core</artifactId>
-  		<version>1.12</version>
+  		<version>2.0</version>
   	</dependency>
   	<dependency>
   		<groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <name>excella-trans</name>
   
   <properties>
-    <java.version>1.7</java.version>
+    <java.version>1.8</java.version>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/org/bbreak/excella/trans/tag/sheet2java/SheetToJavaPropertyParser.java
+++ b/src/main/java/org/bbreak/excella/trans/tag/sheet2java/SheetToJavaPropertyParser.java
@@ -23,6 +23,7 @@ package org.bbreak.excella.trans.tag.sheet2java;
 import java.util.Map;
 
 import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellType;
 import org.bbreak.excella.core.exception.ParseException;
 
 /**
@@ -77,7 +78,7 @@ public abstract class SheetToJavaPropertyParser {
         }
 
         // 文字列かつ、タグを含むセルの場合は処理対象
-        if ( tagCell.getCellType() == Cell.CELL_TYPE_STRING) {
+        if ( tagCell.getCellType() == CellType.STRING) {
             if ( tagCell.getStringCellValue().contains( tag)) {
                 return true;
             }


### PR DESCRIPTION
### This Pull Request Changes
- Bump Apache POI from 3.16 to 4.1.1
    - excella-core/excella-core#28 を前提としているため、excella-coreリリース後のバージョンを設定する必要があります
- Fix complile errors
- Bump target version of Java from 1.7 to 1.8
    - POI 4.0+ requires Java 8